### PR TITLE
Bump rubocop version to 0.88.0

### DIFF
--- a/rubocop-veeqo.gemspec
+++ b/rubocop-veeqo.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |spec|
   spec.authors  = ['Veeqo']
   spec.files    = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.license  = 'MIT'
-  spec.add_dependency 'rubocop', '~> 0.85.0'
+  spec.add_dependency 'rubocop', '~> 0.88.0'
 end


### PR DESCRIPTION
Bumps to closest possible match from list of [supported versions on Hound](http://help.houndci.com/en/articles/2461415-supported-linters).