### PR TITLE
0.0.5: Depend on rubocop 0.88.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.5
+
+- Use Rubocop 0.88.0
+
 # 0.0.4
 
 - Enabled cops:

--- a/lib/rubocop-veeqo.rb
+++ b/lib/rubocop-veeqo.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubocopVeeqo
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/rubocop-veeqo.gemspec
+++ b/rubocop-veeqo.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |spec|
   spec.authors  = ['Veeqo']
   spec.files    = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.license  = 'MIT'
-  spec.add_dependency 'rubocop', '~> 0.85.0'
+  spec.add_dependency 'rubocop', '~> 0.88.0'
 end


### PR DESCRIPTION
This is to align with Hound rubocop (that has a limited list of support rubocop versions)