### PR TITLE
0.0.6: Depend on rubocop 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.6
+
+- Use Rubocop 1.30.0
+
 # 0.0.5
 
 - Use Rubocop 0.88.0

--- a/lib/rubocop-veeqo.rb
+++ b/lib/rubocop-veeqo.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubocopVeeqo
-  VERSION = '0.0.6-temp'
+  VERSION = '0.0.6'
 end

--- a/lib/rubocop-veeqo.rb
+++ b/lib/rubocop-veeqo.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubocopVeeqo
-  VERSION = '0.0.5'
+  VERSION = '0.0.6-temp'
 end

--- a/rubocop-veeqo.gemspec
+++ b/rubocop-veeqo.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |spec|
   spec.authors  = ['Veeqo']
   spec.files    = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.license  = 'MIT'
-  spec.add_dependency 'rubocop', '~> 0.88.0'
+  spec.add_dependency 'rubocop', '~> 1.30.0'
 end


### PR DESCRIPTION
## Summary
Old version is not compatible with ruby 3